### PR TITLE
Changes to makefile to stop deployment symlinking of files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 # your project .env file.  The default is to use Docker for local development.
 #
 
-USE_DOCKER ?= 1
+USE_DOCKER ?= 0
 
 #
 # Ensure the local environment has the right binaries installed.
@@ -28,7 +28,7 @@ default: install start build
 # Bring in the external project dependencies.
 #
 
-install: .env
+install:
 ifeq ("${USE_DOCKER}","1")
 	docker run --rm --interactive --tty  --volume $(PWD):/var/www/html:delegated wodby/drupal-php:7.3-dev /bin/bash -c "composer global require hirak/prestissimo; composer install"
 else
@@ -108,9 +108,6 @@ clean: stop
 #
 # Generate project symlinks and other disposable assets and wiring.
 #
-
-.env:
-	cp .env.example .env
 
 public-file-store:
 ifeq ("${USE_DOCKER}","1")

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ git add .
 git commit -m "Created the project."
 ```
 
+### Create .env file
+
+You should copy the `.env.example` file to `.env` and update for your project.
+
+```
+cp .env.example .env
+```
+
 ### Required configuration
 
 You should configure the project for your needs now. The following amendments need to be made at a minimum:


### PR DESCRIPTION
This PR fixes issues with the current Makefile commands symlinking the files directory on deployment in staging/production environments by;

- Enforcing the default `USE_DOCKER` to `0` if not set in `.env`
- Removing the `.env` file creation to a `README.md` step