### PR TITLE
Remove install_profile setting

### DIFF
--- a/src/settings/01-core.settings.inc
+++ b/src/settings/01-core.settings.inc
@@ -18,18 +18,6 @@
  */
 
 /**
- * The active installation profile.
- *
- * Changing this after installation is not recommended as it changes which
- * directories are scanned during extension discovery. If this is set prior to
- * installation this value will be rewritten according to the profile selected
- * by the user.
- *
- * @see install_select_profile()
- */
-$settings['install_profile'] = 'minimal';
-
-/**
  * Salt for one-time login links, cancel links, form tokens, etc.
  *
  * This variable will be set to a random value by the installer. All one-time


### PR DESCRIPTION
As of Drupal 9, install profile in settings should be removed.

> Drupal 9 no longer uses the $settings['install_profile'] value in settings.php and it should be removed.